### PR TITLE
Add JREBuilder helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This example expects a custom JRE built with 'jlink' and a java application to r
 You will need "tar" and "[crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)" on the PATH. "Wait, is 'crane' not a special tool?" you might be wondering. It is. We need it to interact with OCI registries, which is not the feature to be proven feasible. Concretely, downloading a layer of the "distroless"-image by Google. This particular base image gets us 'libc', SSL certificates and some things we absolutely need from an OS to run the JVM.
 
 ## Usage
+### Build a custom JRE
+```fish
+javac src/***.java -d out
+java -cp out com.assense.OCIImageBuilder.JREBuilder ./app-mods com.example.helloworld ./custom-jre
+```
 ### Run
 ```fish
 javac src/***.java -d out

--- a/src/com/assense/OCIImageBuilder/JREBuilder.java
+++ b/src/com/assense/OCIImageBuilder/JREBuilder.java
@@ -1,0 +1,55 @@
+package com.assense.OCIImageBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+
+/**
+ * Simple helper that creates a custom JRE for a given module using jlink.
+ */
+public class JREBuilder {
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3 || Arrays.asList(args).contains("--help")) {
+            System.out.println("Usage: java JREBuilder <module-path> <module-name> <output-dir>");
+            System.exit(args.length == 0 ? 1 : 0);
+        }
+        build(args[0], args[1], args[2]);
+    }
+
+    /**
+     * Creates a custom JRE at {@code outDir} containing the specified module.
+     */
+    public static void build(String modulePath, String moduleName, String outDir) throws Exception {
+        Path out = Paths.get(outDir);
+        if (Files.exists(out)) deleteDir(out);
+
+        String javaHome = Optional.ofNullable(System.getenv("JAVA_HOME"))
+                .orElseGet(() -> System.getProperty("java.home"));
+        String jmods = Paths.get(javaHome, "jmods").toString();
+
+        runCmd("jlink",
+                "--module-path", jmods + File.pathSeparator + modulePath,
+                "--add-modules", moduleName,
+                "--output", outDir,
+                "--strip-debug",
+                "--no-header-files",
+                "--no-man-pages");
+    }
+
+    static void deleteDir(Path dir) throws IOException {
+        if (!Files.exists(dir)) return;
+        Files.walk(dir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                    try { Files.delete(p); } catch (IOException ignored) {}
+                });
+    }
+
+    static void runCmd(String... cmd) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.inheritIO();
+        Process p = pb.start();
+        if (p.waitFor() != 0) throw new RuntimeException("Command failed: " + String.join(" ", cmd));
+    }
+}

--- a/src/com/assense/OCIImageBuilder/JREBuilderTest.java
+++ b/src/com/assense/OCIImageBuilder/JREBuilderTest.java
@@ -1,0 +1,56 @@
+package com.assense.OCIImageBuilder;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Comparator;
+
+public class JREBuilderTest {
+    public static void main(String[] args) throws Exception {
+        String srcDir = "test-src";
+        String moduleDir = "test-mods";
+        String jreDir = "test-jre";
+        String moduleName = "test.jre";
+
+        cleanDir(srcDir);
+        cleanDir(moduleDir);
+        cleanDir(jreDir);
+
+        Path pkg = Paths.get(srcDir, moduleName.replace('.', '/'));
+        Files.createDirectories(pkg);
+        Files.writeString(Paths.get(srcDir, "module-info.java"),
+                "module " + moduleName + " { exports " + moduleName + "; }");
+        Files.writeString(pkg.resolve("Hello.java"),
+                "package " + moduleName + "; public class Hello { public static void main(String[] args) { System.out.println(\"hi\"); } }");
+
+        runCmd("javac", "-d", moduleDir,
+                Paths.get(srcDir, "module-info.java").toString(),
+                pkg.resolve("Hello.java").toString());
+
+        JREBuilder.build(moduleDir, moduleName, jreDir);
+
+        if (!Files.exists(Paths.get(jreDir, "bin", "java"))) {
+            throw new AssertionError("java executable missing in built JRE");
+        }
+
+        System.out.println("All JREBuilder assertions passed!");
+        cleanDir(srcDir);
+        cleanDir(moduleDir);
+        cleanDir(jreDir);
+    }
+
+    static void runCmd(String... args) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(args);
+        pb.inheritIO();
+        Process p = pb.start();
+        if (p.waitFor() != 0) throw new RuntimeException("Command failed: " + String.join(" ", args));
+    }
+
+    static void cleanDir(String dir) throws IOException {
+        Path d = Paths.get(dir);
+        if (Files.exists(d)) Files.walk(d)
+                .sorted(Comparator.reverseOrder())
+                .forEach(path -> {
+                    try { Files.delete(path); } catch (IOException ignored) {}
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- build a custom JRE using new `JREBuilder`
- document how to run `JREBuilder`
- provide a small test for the builder

## Testing
- `javac $(find src -name '*.java') -d out`
- `java -cp out com.assense.OCIImageBuilder.JREBuilderTest`
- `java com.assense.OCIImageBuilder.OCIImageBuilderTest` *(fails: `crane` missing)*